### PR TITLE
add knife4j support

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/application-linkis.yml
+++ b/assembly-combined-package/assembly-combined/conf/application-linkis.yml
@@ -36,3 +36,8 @@ pagehelper:
 #ribbon:
 #  ReadTimeout: 10000
 #  ConnectTimeout: 10000
+
+##disable  kinif4j.production when you want to use apidoc during development
+knife4j:
+  enable: true
+  production: true

--- a/assembly-combined-package/assembly-combined/conf/linkis.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis.properties
@@ -14,7 +14,7 @@
 #
 
 #
-##
+##enable wds.linkis.test.mode where use knife4j
 #wds.linkis.test.mode=true
 wds.linkis.server.version=v1
 ##spring conf

--- a/linkis-commons/linkis-module/pom.xml
+++ b/linkis-commons/linkis-module/pom.xml
@@ -23,12 +23,21 @@
         <artifactId>linkis</artifactId>
         <groupId>org.apache.linkis</groupId>
         <version>1.0.3</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>linkis-module</artifactId>
 
     <dependencies>
+        <!--add knif2 dependency-->
+        <dependency>
+              <groupId>com.github.xiaoymin</groupId>
+              <artifactId>knife4j-spring-boot-starter</artifactId>
+              <version>${knife4j.version}</version>
+        </dependency>
+
+
         <dependency>
             <groupId>org.apache.linkis</groupId>
             <artifactId>linkis-common</artifactId>

--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/Knife4jConfig.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/Knife4jConfig.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.server.conf
+
+import org.springframework.context.annotation.Bean
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import springfox.documentation.builders.ApiInfoBuilder
+import springfox.documentation.builders.PathSelectors
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.service.ApiInfo
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc
+import org.springframework.beans.factory.annotation.Value
+
+/**
+ * it is very easy to enable knife when you want to use apiDoc(based on swagger2)
+ * you can follow these steps to enable
+ * 1, open application-linkis.yml and set knife4j.production=false
+ * 2, open linkis.properties and set ds.linkis.test.mode=true
+ * 3, restart the service and you can visit http://ip:port/api/rest_j/v1/doc.html
+ *
+ * or you can use apidoc by following steps  without enable ds.linkis.test.mode
+ * 1, open application-linkis.yml and set knife4j.production=false
+ * 2, open linkis.propertes ,and set wds.linkis.server.user.restful.uri.pass.auth=/api/rest_j/v1/doc.html,/api/rest_j/v1/swagger-resources,/api/rest_j/v1/webjars,/api/rest_j/v1/v2/api-docs
+ * 3, restart the service and you can visit http://ip:port/api/rest_j/v1/doc.html
+ * 4, in your browser,add dataworkcloud_inner_request=true, bdp-user-ticket-id's value and  workspaceId's value into cookie
+ */
+@EnableSwagger2WebMvc
+@EnableKnife4j
+@Configuration
+class Knife4jConfig extends WebMvcConfigurer {
+
+  @Value("${spring.application.name}") private val appName = "linkis service"
+
+  @Bean(Array("defaultApi2"))
+  def  defaultApi2() : Docket = {
+     val docket = new Docket(DocumentationType.SWAGGER_2)
+      .apiInfo(apiInfo())
+      //分组名称
+      .groupName("RESTAPI")
+      .select()
+      //这里指定Controller扫描包路径
+      .apis(RequestHandlerSelectors.basePackage("org.apache.linkis"))
+      .paths(PathSelectors.any())
+      .build()
+    docket
+  }
+
+  def  apiInfo() : ApiInfo ={
+    val apiInfo = new ApiInfoBuilder()
+      .title(appName)
+      .description("Linkis micro service RESTful APIs")
+      .version("v1")
+      .build()
+    apiInfo
+  }
+
+  override def addResourceHandlers( registry : ResourceHandlerRegistry): Unit  =  {
+    registry.addResourceHandler("/api/rest_j/v1/doc.html**").addResourceLocations("classpath:/META-INF/resources/doc.html")
+    registry.addResourceHandler("/api/rest_j/v1/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/")
+  }
+
+  override def addViewControllers(registry : ViewControllerRegistry ) : Unit = {
+    registry.addRedirectViewController("/api/rest_j/v1/v2/api-docs", "/v2/api-docs")
+    registry.addRedirectViewController("/api/rest_j/v1/swagger-resources/configuration/ui", "/swagger-resources/configuration/ui")
+    registry.addRedirectViewController("/api/rest_j/v1/swagger-resources/configuration/security", "/swagger-resources/configuration/security")
+    registry.addRedirectViewController("/api/rest_j/v1/swagger-resources", "/swagger-resources")
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <httpclient.version>4.5.4</httpclient.version>
         <httpmime.version>4.5.4</httpmime.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <knife4j.version>2.0.9</knife4j.version>
         <maven.version>3.3.3</maven.version>
         <xstream.core.version>1.4.15</xstream.core.version>
         <spring.version>5.2.12.RELEASE</spring.version>


### PR DESCRIPTION
### What is the purpose of the change
add knife4j to linkis  so that user can use apiDoc during development and debugging code.

### Brief change log
(for example:)
1,add maven depedency on knife4j 2.0.9
2,add knife4jConfiguration
3,add related config param in application-linkis.yml

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): yes
- Anything that affects deployment: no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: no

### Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? JavaDoc 